### PR TITLE
wacker-cli: unify clap attributes and remove unnecessary ones

### DIFF
--- a/wacker-cli/src/commands/delete.rs
+++ b/wacker-cli/src/commands/delete.rs
@@ -3,8 +3,7 @@ use clap::Parser;
 use tonic::transport::Channel;
 use wacker_api::{modules_client::ModulesClient, DeleteRequest};
 
-#[derive(Parser, PartialEq)]
-#[structopt(name = "delete", aliases = &["rm"])]
+#[derive(Parser)]
 pub struct DeleteCommand {
     /// Module ID
     #[arg(required = true)]

--- a/wacker-cli/src/commands/list.rs
+++ b/wacker-cli/src/commands/list.rs
@@ -7,8 +7,7 @@ use tabled::{
 use tonic::transport::Channel;
 use wacker_api::{modules_client::ModulesClient, ModuleStatus};
 
-#[derive(Parser, PartialEq)]
-#[structopt(name = "list", aliases = &["ps"])]
+#[derive(Parser)]
 pub struct ListCommand {}
 
 #[derive(Tabled)]

--- a/wacker-cli/src/commands/logs.rs
+++ b/wacker-cli/src/commands/logs.rs
@@ -4,8 +4,7 @@ use std::process::Command;
 use tonic::transport::Channel;
 use wacker_api::config::LOGS_DIR;
 
-#[derive(Parser, PartialEq)]
-#[structopt(name = "logs", aliases = &["log"])]
+#[derive(Parser)]
 pub struct LogsCommand {
     /// Module ID
     #[arg(required = true)]

--- a/wacker-cli/src/commands/restart.rs
+++ b/wacker-cli/src/commands/restart.rs
@@ -3,8 +3,7 @@ use clap::Parser;
 use tonic::transport::Channel;
 use wacker_api::{modules_client::ModulesClient, RestartRequest};
 
-#[derive(Parser, PartialEq)]
-#[structopt(name = "restart")]
+#[derive(Parser)]
 pub struct RestartCommand {
     /// Module ID
     #[arg(required = true)]

--- a/wacker-cli/src/commands/run.rs
+++ b/wacker-cli/src/commands/run.rs
@@ -3,8 +3,7 @@ use clap::Parser;
 use tonic::transport::Channel;
 use wacker_api::{modules_client::ModulesClient, RunRequest};
 
-#[derive(Parser, PartialEq)]
-#[structopt(name = "run")]
+#[derive(Parser)]
 pub struct RunCommand {
     /// Module file path
     #[arg(required = true)]

--- a/wacker-cli/src/commands/stop.rs
+++ b/wacker-cli/src/commands/stop.rs
@@ -3,8 +3,7 @@ use clap::Parser;
 use tonic::transport::Channel;
 use wacker_api::{modules_client::ModulesClient, StopRequest};
 
-#[derive(Parser, PartialEq)]
-#[structopt(name = "stop")]
+#[derive(Parser)]
 pub struct StopCommand {
     /// Module ID
     #[arg(required = true)]

--- a/wacker-cli/src/main.rs
+++ b/wacker-cli/src/main.rs
@@ -11,23 +11,26 @@ use wacker_api::config::SOCK_PATH;
 #[command(name = "wacker")]
 #[command(author, version, about, long_about = None)]
 struct Wacker {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: Subcommand,
 }
 
-#[derive(Parser, PartialEq)]
+#[derive(Parser)]
 enum Subcommand {
     /// Runs a WebAssembly module
     Run(commands::RunCommand),
-    /// List running WebAssembly modules
+    /// Lists running WebAssembly modules
+    #[command(visible_alias = "ps")]
     List(commands::ListCommand),
     /// Stops a WebAssembly module
     Stop(commands::StopCommand),
-    /// Restart a WebAssembly module
+    /// Restarts a WebAssembly module
     Restart(commands::RestartCommand),
-    /// Delete a WebAssembly module
+    /// Deletes a WebAssembly module
+    #[command(visible_alias = "rm")]
     Delete(commands::DeleteCommand),
-    /// Fetch the logs of a module
+    /// Fetches logs of a module
+    #[command(visible_alias = "log")]
     Logs(commands::LogsCommand),
 }
 


### PR DESCRIPTION
Even though `#[clap()]` still works, `#[arg()]` and `#[command()]` are now recommended since clap v4, ref https://github.com/clap-rs/clap/pull/4180.

before:

```
wacker client

Usage: wacker <COMMAND>

Commands:
  run      Runs a WebAssembly module
  list     List running WebAssembly modules
  stop     Stops a WebAssembly module
  restart  Restart a WebAssembly module
  delete   Delete a WebAssembly module
  logs     Fetch the logs of a module
  help     Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```

after:

```
wacker client

Usage: wacker <COMMAND>

Commands:
  run      Runs a WebAssembly module
  list     Lists running WebAssembly modules [aliases: ps]
  stop     Stops a WebAssembly module
  restart  Restarts a WebAssembly module
  delete   Deletes a WebAssembly module [aliases: rm]
  logs     Fetches logs of a module [aliases: log]
  help     Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```