### PR TITLE
Customize the version information output for CLI

### DIFF
--- a/wacker-cli/build.rs
+++ b/wacker-cli/build.rs
@@ -1,0 +1,26 @@
+use std::process::Command;
+
+fn main() {
+    set_commit_info_for_rustc();
+}
+
+fn set_commit_info_for_rustc() {
+    let output = match Command::new("git")
+        .arg("log")
+        .arg("-1")
+        .arg("--date=short")
+        .arg("--format=%H %h %cd")
+        .output()
+    {
+        // Something like: 1d3b80a2765e46a51290819b82f772dff09c2c49 1d3b80a 2023-12-21
+        Ok(output) if output.status.success() => String::from_utf8(output.stdout).unwrap(),
+        _ => return,
+    };
+    let mut parts = output.split_whitespace().skip(1);
+    println!(
+        "cargo:rustc-env=WACKER_VERSION_INFO={} ({} {})",
+        env!("CARGO_PKG_VERSION"),
+        parts.next().unwrap(),
+        parts.next().unwrap()
+    );
+}

--- a/wacker-cli/src/main.rs
+++ b/wacker-cli/src/main.rs
@@ -6,10 +6,15 @@ use wacker::new_client;
 
 #[derive(Parser)]
 #[command(name = "wacker")]
-#[command(author, version, about, long_about = None)]
+#[command(author, version = version(), about, long_about = None)]
 struct Wacker {
     #[command(subcommand)]
     subcommand: Subcommand,
+}
+
+fn version() -> &'static str {
+    // If WACKER_VERSION_INFO is set, use it, otherwise use CARGO_PKG_VERSION.
+    option_env!("WACKER_VERSION_INFO").unwrap_or(env!("CARGO_PKG_VERSION"))
 }
 
 #[derive(Parser)]

--- a/wacker-daemon/build.rs
+++ b/wacker-daemon/build.rs
@@ -1,0 +1,26 @@
+use std::process::Command;
+
+fn main() {
+    set_commit_info_for_rustc();
+}
+
+fn set_commit_info_for_rustc() {
+    let output = match Command::new("git")
+        .arg("log")
+        .arg("-1")
+        .arg("--date=short")
+        .arg("--format=%H %h %cd")
+        .output()
+    {
+        // Something like: 1d3b80a2765e46a51290819b82f772dff09c2c49 1d3b80a 2023-12-21
+        Ok(output) if output.status.success() => String::from_utf8(output.stdout).unwrap(),
+        _ => return,
+    };
+    let mut parts = output.split_whitespace().skip(1);
+    println!(
+        "cargo:rustc-env=WACKER_VERSION_INFO={} ({} {})",
+        env!("CARGO_PKG_VERSION"),
+        parts.next().unwrap(),
+        parts.next().unwrap()
+    );
+}

--- a/wacker-daemon/src/main.rs
+++ b/wacker-daemon/src/main.rs
@@ -12,8 +12,13 @@ use wacker::{Config, ModulesServer, Server};
 
 #[derive(Parser)]
 #[command(name = "wackerd")]
-#[command(author, version, about, long_about = None)]
+#[command(author, version = version(), about, long_about = None)]
 struct WackerDaemon {}
+
+fn version() -> &'static str {
+    // If WACKER_VERSION_INFO is set, use it, otherwise use CARGO_PKG_VERSION.
+    option_env!("WACKER_VERSION_INFO").unwrap_or(env!("CARGO_PKG_VERSION"))
+}
 
 impl WackerDaemon {
     async fn execute(self) -> Result<()> {

--- a/wacker/Cargo.toml
+++ b/wacker/Cargo.toml
@@ -33,4 +33,5 @@ const_format = "0.2.32"
 async-stream = "0.3.5"
 
 [build-dependencies]
+anyhow.workspace = true
 tonic-build = "0.10.2"

--- a/wacker/build.rs
+++ b/wacker/build.rs
@@ -1,4 +1,6 @@
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+use anyhow::Result;
+
+fn main() -> Result<()> {
     tonic_build::compile_protos("proto/module.proto")?;
     Ok(())
 }


### PR DESCRIPTION
Add the commit id and commit date to the version information output.

before:

```
wacker 0.2.1
```

after:

```
wacker 0.2.1 (1d3b80a 2023-12-21)
```