### PR TITLE
wacker: use fuzzy id matching in delete/stop/restart/logs operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2760,6 +2760,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "prost",
  "rand",
+ "rayon",
  "reqwest",
  "serde",
  "sled",

--- a/wacker/Cargo.toml
+++ b/wacker/Cargo.toml
@@ -43,6 +43,7 @@ env_logger = "0.11.3"
 chrono = "0.4.38"
 sled = "0.34.7"
 log = "0.4.21"
+rayon = "1.10.0"
 
 [build-dependencies]
 anyhow.workspace = true


### PR DESCRIPTION
It is now possible to manage the program by just entering the unique prefix of the id, eg:

```
$ wacker list
ID             PATH                  STATUS     ADDRESS
cli-Q6kBmfX    /Users/xxx/cli.wasm   Finished
http-WNt3TDX   /Users/xxx/http.wasm  Running    0.0.0.0:8080

$ wacker rm/restart/logs cli
```